### PR TITLE
fixed submissions state with checkmarks responding as intended to bac…

### DIFF
--- a/src/app/components/child-dashboard/creative-content-submission/drawing-form/drawing-form.component.tsx
+++ b/src/app/components/child-dashboard/creative-content-submission/drawing-form/drawing-form.component.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useHistory } from 'react-router';
 import { Link } from 'react-router-dom';
 import {
@@ -10,88 +10,8 @@ import {
     Button,
     LinearProgress,
 } from '@material-ui/core';
-import { makeStyles } from '@material-ui/core/styles';
-import cityscape from '../../../../pages/child-dashboard/icons/cityscape.png';
 import { useAPI, useForm } from '../../../../hooks';
-
-const useStyles = makeStyles((theme) => ({
-    header: {
-        color: theme.palette.primary.contrastText,
-        backgroundColor: theme.palette.primary.main,
-        borderBottom: '7px solid #000000',
-    },
-    card: {
-        borderLeft: '7px solid #000000',
-        borderBottom: '7px solid #000000',
-        borderRight: '7px solid #000000',
-    },
-    content: {
-        display: 'flex',
-        flexDirection: 'column',
-    },
-    form: {
-        margin: '0 auto',
-        width: '50%',
-    },
-    preview: {
-        height: 200,
-        width: 200,
-    },
-    wrapper: {
-        margin: theme.spacing(1),
-        position: 'fixed',
-        bottom: theme.spacing(2),
-        right: theme.spacing(2),
-    },
-    orangeButton: {
-        'backgroundColor': '#FF6B35',
-        'fontSize': '24px',
-        'fontWeight': 'bold',
-        'borderRadius': '10px',
-        'color': 'white',
-        'width': '200px',
-        'border': '3px solid #292929',
-        'textTransform': 'capitalize',
-        'fontFamily': 'nunito',
-        '&:hover': {
-            backgroundColor: '#FF6B35',
-        },
-    },
-    buttonText: {
-        fontSize: '24px',
-        fontWeight: 'bold',
-        fontFamily: 'nunito',
-    },
-    appBar: {
-        height: '229px',
-        backgroundColor: '#6CEAE6',
-        backgroundImage: `url(${cityscape})`,
-        backgroundRepeat: 'no-repeat',
-        backgroundSize: '101% 103%',
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
-    },
-    headerFont: {
-        'fontFamily': 'Bangers',
-        'color': '#FFFFFF',
-        'fontSize': '86px',
-        'fontWeight': 'bold',
-        '-webkit-text-stroke-width': '1px',
-        '-webkit-text-stroke-color': '#000000',
-    },
-    buttons: {
-        display: 'flex',
-        justifyContent: 'space-between',
-    },
-    promptText: {
-        fontFamily: 'nunito',
-        fontSize: '36px',
-        fontWeight: 'normal',
-        color: '#292929',
-    },
-}));
-
+import { useStyles } from './styles';
 interface DrawingFormProps {
     onUpdate?: () => void;
     week: number;
@@ -104,7 +24,7 @@ const DrawingForm: React.FC<DrawingFormProps> = ({ week, onUpdate }) => {
     const [currentSubmission] = useAPI(`/illustrationRoutes/${week}`, 'GET', false);
     const [submission, submitting, submit] = useAPI('/illustrationRoutes', 'POST');
     const [removed, removing, remove] = useAPI(`/illustrationRoutes/${week}`, 'DELETE');
-    const [newProgress, progressing, progress] = useAPI('/children/progress', 'POST');
+    // const [newProgress, progressing, progress] = useAPI('/children/progress', 'POST');
     const { state, setState, handleInputChange, handleFileChange, handleSubmitBuilder } = useForm({
         illustration: '',
     });
@@ -117,16 +37,8 @@ const DrawingForm: React.FC<DrawingFormProps> = ({ week, onUpdate }) => {
         remove();
     };
 
-    React.useEffect(() => {
-        if (removed && currentSubmission && currentSubmission?.illustration) {
-            currentSubmission.illustration = undefined;
-            setState({
-                illustration: '',
-            });
-        }
-    }, [removed, currentSubmission, setState, remove]);
-
-    React.useEffect(() => {
+    useEffect(() => {
+        //initial mount render
         if (
             currentSubmission &&
             currentSubmission?.illustration &&
@@ -138,28 +50,29 @@ const DrawingForm: React.FC<DrawingFormProps> = ({ week, onUpdate }) => {
         }
     }, [currentSubmission, setState]);
 
-    React.useEffect(() => {
-        if (
-            submission &&
-            submission?.illustration &&
-            Object.keys(submission?.illustration).length
-        ) {
-            progress({ drawing: true });
-            setSubmitted(true);
-        }
-        if (removed && Object.keys(removed).length) {
-            progress({ drawing: false });
+    useEffect(() => {
+        //checks if BE returned deleted as removed 4.1.20
+        if (removed) {
             setState({
                 illustration: '',
             });
             setSubmitted(false);
         }
-    }, [submission, removed, progress, setState, currentSubmission]);
+    }, [removed, remove]);
 
-    React.useEffect(() => {
-        if (newProgress && onUpdate) onUpdate();
-        if (newProgress?.progress?.drawing) history.push('/kids-dashboard');
-    }, [history, onUpdate, newProgress]);
+    useEffect(() => {
+        //POST: checks if BE returned submission success as submission 4.1.20
+        if (submission && submission?.illustrations && submission?.illustrations.illustration) {
+            setSubmitted(true);
+        }
+    }, [submission, setState, currentSubmission]);
+
+    useEffect(() => {
+        if (onUpdate) onUpdate();
+        if (submission && submission?.illustrations && submission?.illustrations.illustration) {
+            history.push('/kids-dashboard');
+        }
+    }, [submitted]);
 
     const { illustration } = state;
     return (

--- a/src/app/components/child-dashboard/creative-content-submission/drawing-form/drawing-form.component.tsx
+++ b/src/app/components/child-dashboard/creative-content-submission/drawing-form/drawing-form.component.tsx
@@ -21,8 +21,8 @@ const DrawingForm: React.FC<DrawingFormProps> = ({ week, onUpdate }) => {
     const classes = useStyles({});
     const history = useHistory();
     const [submitted, setSubmitted] = React.useState(false);
-    const [currentSubmission] = useAPI(`/illustrationRoutes/${week}`, 'GET', false);
-    const [submission, submitting, submit] = useAPI('/illustrationRoutes', 'POST');
+    const [fetchedDrawing] = useAPI(`/illustrationRoutes/${week}`, 'GET', false);
+    const [uploadedDrawing, loadingDrawing, submitDrawing] = useAPI('/illustrationRoutes', 'POST');
     const [removed, removing, remove] = useAPI(`/illustrationRoutes/${week}`, 'DELETE');
     // const [newProgress, progressing, progress] = useAPI('/children/progress', 'POST');
     const { state, setState, handleInputChange, handleFileChange, handleSubmitBuilder } = useForm({
@@ -30,7 +30,7 @@ const DrawingForm: React.FC<DrawingFormProps> = ({ week, onUpdate }) => {
     });
 
     const handleSubmit = handleSubmitBuilder(() => {
-        submit(state);
+        submitDrawing(state);
     });
 
     const handleDelete = () => {
@@ -40,15 +40,15 @@ const DrawingForm: React.FC<DrawingFormProps> = ({ week, onUpdate }) => {
     useEffect(() => {
         //initial mount render
         if (
-            currentSubmission &&
-            currentSubmission?.illustration &&
-            Object.keys(currentSubmission?.illustration).length
+            fetchedDrawing &&
+            fetchedDrawing?.illustration &&
+            Object.keys(fetchedDrawing?.illustration).length
         ) {
-            const { illustration } = currentSubmission;
+            const { illustration } = fetchedDrawing;
             setState(illustration);
             setSubmitted(true);
         }
-    }, [currentSubmission, setState]);
+    }, [fetchedDrawing, setState]);
 
     useEffect(() => {
         //checks if BE returned deleted as removed 4.1.20
@@ -62,14 +62,14 @@ const DrawingForm: React.FC<DrawingFormProps> = ({ week, onUpdate }) => {
 
     useEffect(() => {
         //POST: checks if BE returned submission success as submission 4.1.20
-        if (submission && submission?.illustrations && submission?.illustrations.illustration) {
+        if (uploadedDrawing && uploadedDrawing?.illustrations && uploadedDrawing?.illustrations.illustration) {
             setSubmitted(true);
         }
-    }, [submission, setState, currentSubmission]);
+    }, [uploadedDrawing, fetchedDrawing]);
 
     useEffect(() => {
         if (onUpdate) onUpdate();
-        if (submission && submission?.illustrations && submission?.illustrations.illustration) {
+        if (uploadedDrawing && uploadedDrawing?.illustrations && uploadedDrawing?.illustrations.illustration) {
             history.push('/kids-dashboard');
         }
     }, [submitted]);
@@ -117,7 +117,7 @@ const DrawingForm: React.FC<DrawingFormProps> = ({ week, onUpdate }) => {
                 </Fab>
             </div>
             <div>
-                {submitting && (
+                {loadingDrawing && (
                     <>
                         {' '}
                         <h2>Sending Progress...</h2>
@@ -125,7 +125,7 @@ const DrawingForm: React.FC<DrawingFormProps> = ({ week, onUpdate }) => {
                     </>
                 )}
             </div>
-            {submitting && <LinearProgress variant='query' color='secondary' />}
+            {loadingDrawing && <LinearProgress variant='query' color='secondary' />}
         </form>
     );
 };

--- a/src/app/components/child-dashboard/creative-content-submission/drawing-form/styles.ts
+++ b/src/app/components/child-dashboard/creative-content-submission/drawing-form/styles.ts
@@ -1,0 +1,79 @@
+import { makeStyles } from '@material-ui/core/styles';
+import cityscape from '../../../../pages/child-dashboard/icons/cityscape.png';
+export const useStyles = makeStyles((theme) => ({
+    header: {
+        color: theme.palette.primary.contrastText,
+        backgroundColor: theme.palette.primary.main,
+        borderBottom: '7px solid #000000',
+    },
+    card: {
+        borderLeft: '7px solid #000000',
+        borderBottom: '7px solid #000000',
+        borderRight: '7px solid #000000',
+    },
+    content: {
+        display: 'flex',
+        flexDirection: 'column',
+    },
+    form: {
+        margin: '0 auto',
+        width: '50%',
+    },
+    preview: {
+        height: 200,
+        width: 200,
+    },
+    wrapper: {
+        margin: theme.spacing(1),
+        position: 'fixed',
+        bottom: theme.spacing(2),
+        right: theme.spacing(2),
+    },
+    orangeButton: {
+        'backgroundColor': '#FF6B35',
+        'fontSize': '24px',
+        'fontWeight': 'bold',
+        'borderRadius': '10px',
+        'color': 'white',
+        'width': '200px',
+        'border': '3px solid #292929',
+        'textTransform': 'capitalize',
+        'fontFamily': 'nunito',
+        '&:hover': {
+            backgroundColor: '#FF6B35',
+        },
+    },
+    buttonText: {
+        fontSize: '24px',
+        fontWeight: 'bold',
+        fontFamily: 'nunito',
+    },
+    appBar: {
+        height: '229px',
+        backgroundColor: '#6CEAE6',
+        backgroundImage: `url(${cityscape})`,
+        backgroundRepeat: 'no-repeat',
+        backgroundSize: '101% 103%',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    headerFont: {
+        'fontFamily': 'Bangers',
+        'color': '#FFFFFF',
+        'fontSize': '86px',
+        'fontWeight': 'bold',
+        '-webkit-text-stroke-width': '1px',
+        '-webkit-text-stroke-color': '#000000',
+    },
+    buttons: {
+        display: 'flex',
+        justifyContent: 'space-between',
+    },
+    promptText: {
+        fontFamily: 'nunito',
+        fontSize: '36px',
+        fontWeight: 'normal',
+        color: '#292929',
+    },
+}));

--- a/src/app/components/child-dashboard/kid-progress/kid-progress.component.tsx
+++ b/src/app/components/child-dashboard/kid-progress/kid-progress.component.tsx
@@ -82,15 +82,6 @@ const KidProgressCard: React.FC<KidProgressProps> = ({ child, onUpdate }) => {
             setOpen(false);
         }
     }, [progress.reading]);
-    React.useEffect(() => {
-        console.log('log of child obj within kidprogress', child);
-        if (child.illustrations.length) {
-            console.log('illustrations true');
-        }
-        if (child.stories.length) {
-            console.log('stories true');
-        }
-    }, []);
     return (
         <>
             <Card className={classes.card}>

--- a/src/app/pages/child-dashboard/child-dashboard.page.tsx
+++ b/src/app/pages/child-dashboard/child-dashboard.page.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useHistory } from 'react-router-dom';
 
 import { CircularProgress } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';


### PR DESCRIPTION
Description: 

This PR should completely fix the FE issues we were having with submission state not being precisely adjusted from user interaction

Fixes # (issue)

Back button not refreshing dashboard state(checkmarks)
- This didn't need to be fixed, state refresh is triggered through 'refresh' & 'submit'
Refresh button not refreshing state
Submit not re-directing

## Type of change

- [x] Clean up/rename story form
- [x] Refresh and submit working as intended with writing/drawing state updated through the submission itself rather than progress object
- [x] Extract styling from drawing form
- [x] Fix drawing form naming