### PR TITLE
Feature/disable repeat submissions

### DIFF
--- a/src/app/components/child-dashboard/creative-content-submission/drawing-form/drawing-form.component.tsx
+++ b/src/app/components/child-dashboard/creative-content-submission/drawing-form/drawing-form.component.tsx
@@ -118,7 +118,8 @@ const DrawingForm: React.FC<DrawingFormProps> = ({ week, onUpdate }) => {
                     className={classes.orangeButton}
                     type={submitted ? undefined : 'submit'}
                     color='primary'
-                    onClick={submitted ? () => handleDelete() : undefined}>
+                    onClick={submitted ? () => handleDelete() : undefined}
+                    disabled={loadingDrawing}>
                     <Typography className={classes.buttonText}>
                         {submitted ? 'refresh' : 'Submit'}
                     </Typography>

--- a/src/app/components/child-dashboard/creative-content-submission/story-form/story-form.component.tsx
+++ b/src/app/components/child-dashboard/creative-content-submission/story-form/story-form.component.tsx
@@ -155,7 +155,8 @@ const StoryForm: React.FC<StoryFormProps> = ({ week, onUpdate }) => {
                     className={classes.orangeButton}
                     type={submitted ? undefined : 'submit'}
                     color='primary'
-                    onClick={submitted ? () => handleDelete() : undefined}>
+                    onClick={submitted ? () => handleDelete() : undefined}
+                    disabled={loadingStory}>
                     <Typography className={classes.buttonText}>
                         {submitted ? 'refresh' : 'Submit'}
                     </Typography>


### PR DESCRIPTION
# Description
Set disabled attribute on each submit button equal to loadingStory/loadingDrawing so that disabled equals true after the POST request is initialized

Fixes # (issue)
Fixes issue of duplicate values getting stored in the back end when a user clicks submit more than once while completing POST request

